### PR TITLE
Improvement | Release build with api key | Gabriel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply from: "$project.rootDir/tools/script-signing.gradle"
 apply from: "$project.rootDir/tools/app_versioning.gradle"
+apply from: "$project.rootDir/tools/app_update_key.gradle"
 
 android {
 

--- a/tools/app_update_key.gradle
+++ b/tools/app_update_key.gradle
@@ -1,0 +1,7 @@
+task updateApiKey {
+    doFirst {
+        ant.replaceregexp (file: "$project.rootDir/tvnetwork/src/main/res/values/api_keys.xml",
+                match: "$match", flags: 'g',
+                replace: "$key")
+    }
+}

--- a/tools/app_versioning.gradle
+++ b/tools/app_versioning.gradle
@@ -19,15 +19,6 @@ def getAppVersionFile() {
     return file(getAppVersionPath())
 }
 
-private String getCurrentBranch() {
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-        standardOutput = stdout
-    }
-    return stdout.toString().trim()
-}
-
 private String getAppVersionPath() {
     return "$project.rootDir/tools/app_version_code.properties"
 }
@@ -40,34 +31,6 @@ private Integer getVersionNameMajor() {
     return (getVersionProps(getAppVersionFile())[TAG_VERSION_NAME] =~ /\d+/)[0].toInteger()
 }
 
-private static String getDate() {
-    return new Date().format("yyyyMMdd")
-}
-
-private void commitAndSetTag(String versionName, String versionCode) {
-    createCommitForVersion(versionName, versionCode, getAppVersionPath())
-    createTagForVersion(versionName)
-}
-
-private void createCommitForVersion(String versionName, String versionCode, String affectedFile) {
-    Process addChanges = ['git', 'add', affectedFile].execute(null, project.rootDir)
-    addChanges.waitForProcessOutput(System.out, System.err)
-
-    Process createCommit = ['git', 'commit', "-m :star: Release | ${versionName}. Code:${versionCode} | CD | Bitrise"].execute(null, project.rootDir)
-    createCommit.waitForProcessOutput(System.out, System.err)
-}
-
-private void pushChanges() {
-    def branchName = getCurrentBranch()
-    Process pushChanges = ['git', 'push', "origin", branchName].execute(null, project.rootDir)
-    pushChanges.waitForProcessOutput(System.out, System.err)
-}
-
-private void createTagForVersion(String versionName) {
-    Process createTag = ['git', 'tag', "v${versionName}".toString()].execute(null, project.rootDir)
-    createTag.waitForProcessOutput(System.out, System.err)
-}
-
 private void saveVersionChanges(String versionName, Integer versionCode) {
     def versionProps = getVersionProps(getAppVersionFile())
     versionProps[TAG_VERSION_NAME] = versionName
@@ -77,12 +40,9 @@ private void saveVersionChanges(String versionName, Integer versionCode) {
 
 private static String generateVersionName(Integer versionNameMajor,
                                           Integer versionNameMinor,
-                                          String date,
                                           Integer versionCode) {
     String versionName = "${versionNameMajor}.${versionNameMinor}"
-    if (versionCode != null && date != null) {
-        versionName += ".${date}-${versionCode}"
-    } else if (versionCode != null) {
+    if (versionCode != null) {
         versionName += ".${versionCode}"
     }
     return versionName
@@ -106,9 +66,7 @@ task incrementVersionCode {
         def versionCode = getBuildNumber()
         def versionNameMajor = getVersionNameMajor()
         def versionNameMinor = getVersionNameMinor()
-        def versionName = generateVersionName(versionNameMajor, versionNameMinor, getDate(), versionCode)
+        def versionName = generateVersionName(versionNameMajor, versionNameMinor, versionCode)
         saveVersionChanges(versionName, versionCode)
-        commitAndSetTag(versionName, versionCode.toString())
-        pushChanges()
     }
 }

--- a/tvnetwork/src/main/res/values/api_keys.xml
+++ b/tvnetwork/src/main/res/values/api_keys.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!--Add api key in order to make the works-->
-    <string name="tv_api_key"></string>
+    <string name="tv_api_key">xxx</string>
 
 </resources>


### PR DESCRIPTION
**Issue**
Builds from Bitrise were not showing anything due to the empty API key

**Solution**
Create a gradle task to update API key before create the release version with Bitrise (that way the key is not present in the project)